### PR TITLE
 Parametric NLPModelMeta

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-NLPModels = "0.14"
+NLPModels = "0.15"
 NLPModelsModifiers = "0.1"
 julia = "^1.3.0"

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 NLPModels = "0.15"
-NLPModelsModifiers = "0.1"
+NLPModelsModifiers = "0.2"
 julia = "^1.3.0"

--- a/src/nlp/problems/brownden.jl
+++ b/src/nlp/problems/brownden.jl
@@ -19,8 +19,8 @@ export BROWNDEN
 
 Starting point: `[25.0; 5.0; -5.0; -1.0]`
 """
-mutable struct BROWNDEN <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct BROWNDEN{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nlp/problems/brownden.jl
+++ b/src/nlp/problems/brownden.jl
@@ -24,11 +24,12 @@ mutable struct BROWNDEN{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function BROWNDEN()
-  meta = NLPModelMeta(4, x0=[25.0; 5.0; -5.0; -1.0], name="BROWNDEN_manual", nnzh=10)
+function BROWNDEN(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(4, x0=T[25; 5; -5; -1], name="BROWNDEN_manual", nnzh=10)
 
   return BROWNDEN(meta, Counters())
 end
+BROWNDEN() = BROWNDEN(Float64)
 
 function NLPModels.obj(nlp :: BROWNDEN, x :: AbstractVector{T}) where T
   @lencheck 4 x

--- a/src/nlp/problems/hs10.jl
+++ b/src/nlp/problems/hs10.jl
@@ -14,8 +14,8 @@ export HS10
 
 Starting point: `[-10; 10]`.
 """
-mutable struct HS10 <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct HS10{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nlp/problems/hs10.jl
+++ b/src/nlp/problems/hs10.jl
@@ -19,12 +19,19 @@ mutable struct HS10{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function HS10()
-  meta = NLPModelMeta(2, ncon=1, x0=[-10.0; 10.0],
-                      lcon=[0.0], ucon=[Inf], name="HS10_manual")
+function HS10(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    ncon=1,
+    x0=T[-10; 10],
+    lcon=T[0],
+    ucon=T[Inf],
+    name="HS10_manual",
+  )
 
   return HS10(meta, Counters())
 end
+HS10() = HS10(Float64)
 
 function NLPModels.obj(nlp :: HS10, x :: AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs11.jl
+++ b/src/nlp/problems/hs11.jl
@@ -19,11 +19,21 @@ mutable struct HS11{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function HS11()
-  meta = NLPModelMeta(2, ncon=1, nnzh=2, nnzj=2, x0=[4.9; 0.1], lcon=[-Inf], ucon=[0.0], name="HS11_manual")
+function HS11(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    ncon=1,
+    nnzh=2,
+    nnzj=2,
+    x0=T[4.9; 0.1],
+    lcon=T[-Inf],
+    ucon=T[0],
+    name="HS11_manual",
+  )
 
   return HS11(meta, Counters())
 end
+HS11() = HS11(Float64)
 
 function NLPModels.obj(nlp :: HS11, x :: AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs11.jl
+++ b/src/nlp/problems/hs11.jl
@@ -14,8 +14,8 @@ export HS11
 
 Starting point: `[-4.9; 0.1]`.
 """
-mutable struct HS11 <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct HS11{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nlp/problems/hs14.jl
+++ b/src/nlp/problems/hs14.jl
@@ -15,8 +15,8 @@ export HS14
 
 Starting point: `[2; 2]`.
 """
-mutable struct HS14 <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct HS14{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nlp/problems/hs14.jl
+++ b/src/nlp/problems/hs14.jl
@@ -20,11 +20,20 @@ mutable struct HS14{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function HS14()
-  meta = NLPModelMeta(2, nnzh=2, ncon=2, x0=[2.0; 2.0], lcon=[0.0; 0.0], ucon=[0.0; Inf], name="HS14_manual")
+function HS14(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    nnzh=2,
+    ncon=2,
+    x0=T[2; 2],
+    lcon=T[0; 0],
+    ucon=T[0; Inf],
+    name="HS14_manual",
+  )
 
   return HS14(meta, Counters())
 end
+HS14() = HS14(Float64)
 
 function NLPModels.obj(nlp :: HS14, x :: AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs5.jl
+++ b/src/nlp/problems/hs5.jl
@@ -20,11 +20,18 @@ mutable struct HS5{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function HS5()
-  meta = NLPModelMeta(2, x0=zeros(2), lvar=[-1.5; -3.0], uvar=[4.0; 3.0], name="HS5_manual")
+function HS5(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    x0=zeros(T, 2),
+    lvar=T[-1.5; -3],
+    uvar=T[4; 3],
+    name="HS5_manual",
+  )
 
   return HS5(meta, Counters())
 end
+HS5() = HS5(Float64)
 
 function NLPModels.obj(nlp :: HS5, x :: AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs5.jl
+++ b/src/nlp/problems/hs5.jl
@@ -15,8 +15,8 @@ export HS5
 
 Starting point: `[0.0; 0.0]`.
 """
-mutable struct HS5 <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct HS5{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nlp/problems/hs6.jl
+++ b/src/nlp/problems/hs6.jl
@@ -14,8 +14,8 @@ export HS6
 
 Starting point: `[-1.2; 1.0]`.
 """
-mutable struct HS6 <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct HS6{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nlp/problems/hs6.jl
+++ b/src/nlp/problems/hs6.jl
@@ -19,11 +19,21 @@ mutable struct HS6{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function HS6()
-  meta = NLPModelMeta(2, ncon=1, nnzh=1, nnzj=2, x0=[-1.2; 1.0], lcon=[0.0], ucon=[0.0], name="HS6_manual")
+function HS6(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    ncon=1,
+    nnzh=1,
+    nnzj=2,
+    x0=T[-1.2; 1],
+    lcon=T[0],
+    ucon=T[0],
+    name="HS6_manual",
+  )
 
   return HS6(meta, Counters())
 end
+HS6() = HS6(Float64)
 
 function NLPModels.obj(nlp :: HS6, x :: AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/lincon.jl
+++ b/src/nlp/problems/lincon.jl
@@ -29,11 +29,21 @@ mutable struct LINCON{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function LINCON()
-  meta = NLPModelMeta(15, nnzh=15, nnzj=17, ncon=11, x0=zeros(15), lcon = [22.0; 1.0; -Inf; -11.0; -1.0; 1.0; -5.0; -6.0; -Inf * ones(3)], ucon=[22.0; Inf; 16.0; 9.0; -1.0; 1.0; Inf * ones(2); 1.0; 2.0; 3.0], name="LINCON_manual")
+function LINCON(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    15,
+    nnzh=15,
+    nnzj=17,
+    ncon=11,
+    x0=zeros(T, 15),
+    lcon=T[22; 1; -Inf; -11; -1; 1; -5; -6; -Inf * ones(3)],
+    ucon=T[22; Inf; 16; 9; -1; 1; Inf * ones(2); 1; 2; 3],
+    name="LINCON_manual",
+  )
 
   return LINCON(meta, Counters())
 end
+LINCON() = LINCON(Float64)
 
 function NLPModels.obj(nlp :: LINCON, x :: AbstractVector)
   @lencheck 15 x

--- a/src/nlp/problems/lincon.jl
+++ b/src/nlp/problems/lincon.jl
@@ -24,8 +24,8 @@ export LINCON
 
 Starting point: `zeros(15)`.
 """
-mutable struct LINCON <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct LINCON{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nlp/problems/linsv.jl
+++ b/src/nlp/problems/linsv.jl
@@ -20,11 +20,21 @@ mutable struct LINSV{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function LINSV()
-  meta = NLPModelMeta(2, nnzh=0, nnzj=3, ncon=2, x0=zeros(2), lcon = [3.0; 1.0], ucon=[Inf; Inf], name="LINSV_manual")
+function LINSV(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    nnzh=0,
+    nnzj=3,
+    ncon=2,
+    x0=zeros(T, 2),
+    lcon=T[3; 1],
+    ucon=T[Inf; Inf],
+    name="LINSV_manual",
+  )
 
   return LINSV(meta, Counters())
 end
+LINSV() = LINSV(Float64)
 
 function NLPModels.obj(nlp :: LINSV, x :: AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/linsv.jl
+++ b/src/nlp/problems/linsv.jl
@@ -15,13 +15,13 @@ export LINSV
 
 Starting point: `[0; 0]`.
 """
-mutable struct LINSV <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct LINSV{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 
 function LINSV()
-  meta = NLPModelMeta(2, nnzh=0, nnzj=3, ncon=2, x0=zeros(2), lcon = [3; 1], ucon=[Inf; Inf], name="LINSV_manual")
+  meta = NLPModelMeta(2, nnzh=0, nnzj=3, ncon=2, x0=zeros(2), lcon = [3.0; 1.0], ucon=[Inf; Inf], name="LINSV_manual")
 
   return LINSV(meta, Counters())
 end

--- a/src/nlp/problems/mgh01feas.jl
+++ b/src/nlp/problems/mgh01feas.jl
@@ -25,11 +25,21 @@ mutable struct MGH01Feas{T, S} <: AbstractNLPModel{T, S}
   counters :: Counters
 end
 
-function MGH01Feas()
-  meta = NLPModelMeta(2, x0=[-1.2; 1.0], name="MGH01Feas_manual", ncon=2, lcon=zeros(2), ucon=zeros(2), nnzj=3, nnzh=1)
+function MGH01Feas(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    x0=T[-1.2; 1.0],
+    name="MGH01Feas_manual",
+    ncon=2,
+    lcon=zeros(T, 2),
+    ucon=zeros(T, 2),
+    nnzj=3,
+    nnzh=1,
+  )
 
   return MGH01Feas(meta, Counters())
 end
+MGH01Feas() = MGH01Feas(Float64)
 
 function NLPModels.obj(nlp :: MGH01Feas, x :: AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/mgh01feas.jl
+++ b/src/nlp/problems/mgh01feas.jl
@@ -20,8 +20,8 @@ export MGH01Feas
 
 Starting point: `[-1.2; 1]`.
 """
-mutable struct MGH01Feas <: AbstractNLPModel
-  meta :: NLPModelMeta
+mutable struct MGH01Feas{T, S} <: AbstractNLPModel{T, S}
+  meta :: NLPModelMeta{T, S}
   counters :: Counters
 end
 

--- a/src/nls/problems/lls.jl
+++ b/src/nls/problems/lls.jl
@@ -22,9 +22,9 @@ x_2 - 2
 
 Starting point: `[0; 0]`.
 """
-mutable struct LLS <: AbstractNLSModel
-  meta :: NLPModelMeta
-  nls_meta :: NLSMeta
+mutable struct LLS{T, S} <: AbstractNLSModel{T, S}
+  meta :: NLPModelMeta{T, S}
+  nls_meta :: NLSMeta{T, S}
   counters :: NLSCounters
 end
 

--- a/src/nls/problems/lls.jl
+++ b/src/nls/problems/lls.jl
@@ -28,12 +28,21 @@ mutable struct LLS{T, S} <: AbstractNLSModel{T, S}
   counters :: NLSCounters
 end
 
-function LLS()
-  meta = NLPModelMeta(2, x0=zeros(2), name="LLS_manual", ncon=1, lcon=[0.0], ucon=[Inf], nnzj=2)
-  nls_meta = NLSMeta(3, 2, nnzj=5, nnzh=0)
+function LLS(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    x0=zeros(T, 2),
+    name="LLS_manual",
+    ncon=1,
+    lcon=T[0.0],
+    ucon=T[Inf],
+    nnzj=2,
+  )
+  nls_meta = NLSMeta{T, Vector{T}}(3, 2, nnzj=5, nnzh=0)
 
   return LLS(meta, nls_meta, NLSCounters())
 end
+LLS() = LLS(Float64)
 
 function NLPModels.residual!(nls :: LLS, x :: AbstractVector, Fx :: AbstractVector)
   @lencheck 2 x

--- a/src/nls/problems/mgh01.jl
+++ b/src/nls/problems/mgh01.jl
@@ -33,12 +33,13 @@ mutable struct MGH01{T, S} <: AbstractNLSModel{T, S}
   counters :: NLSCounters
 end
 
-function MGH01()
-  meta = NLPModelMeta(2, x0=[-1.2; 1.0], name="MGH01_manual")
-  nls_meta = NLSMeta(2, 2, nnzj=3, nnzh=1)
+function MGH01(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(2, x0=T[-1.2; 1], name="MGH01_manual")
+  nls_meta = NLSMeta{T, Vector{T}}(2, 2, nnzj=3, nnzh=1)
 
   return MGH01(meta, nls_meta, NLSCounters())
 end
+MGH01() = MGH01(Float64)
 
 function NLPModels.residual!(nls :: MGH01, x :: AbstractVector, Fx :: AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/mgh01.jl
+++ b/src/nls/problems/mgh01.jl
@@ -27,9 +27,9 @@ F(x) = \\begin{bmatrix}
 
 Starting point: `[-1.2; 1]`.
 """
-mutable struct MGH01 <: AbstractNLSModel
-  meta :: NLPModelMeta
-  nls_meta :: NLSMeta
+mutable struct MGH01{T, S} <: AbstractNLSModel{T, S}
+  meta :: NLPModelMeta{T, S}
+  nls_meta :: NLSMeta{T, S}
   counters :: NLSCounters
 end
 

--- a/src/nls/problems/nlshs20.jl
+++ b/src/nls/problems/nlshs20.jl
@@ -30,12 +30,23 @@ mutable struct NLSHS20{T, S} <: AbstractNLSModel{T, S}
   counters :: NLSCounters
 end
 
-function NLSHS20()
-  meta = NLPModelMeta(2, x0=[-2.0; 1.0], name="NLSHS20_manual", lvar=[-0.5; -Inf], uvar=[0.5; Inf], ncon=3, lcon=zeros(3), ucon=fill(Inf, 3), nnzj=6)
-  nls_meta = NLSMeta(2, 2, nnzj=3, nnzh=1)
+function NLSHS20(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    2,
+    x0=T[-2.0; 1.0],
+    name="NLSHS20_manual",
+    lvar=T[-0.5; -Inf],
+    uvar=T[0.5; Inf],
+    ncon=3,
+    lcon=zeros(T, 3),
+    ucon=fill(T(Inf), 3),
+    nnzj=6,
+  )
+  nls_meta = NLSMeta{T, Vector{T}}(2, 2, nnzj=3, nnzh=1)
 
   return NLSHS20(meta, nls_meta, NLSCounters())
 end
+NLSHS20() = NLSHS20(Float64)
 
 function NLPModels.residual!(nls :: NLSHS20, x :: AbstractVector, Fx :: AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/nlshs20.jl
+++ b/src/nls/problems/nlshs20.jl
@@ -24,9 +24,9 @@ F(x) = \\begin{bmatrix}
 
 Starting point: `[-2; 1]`.
 """
-mutable struct NLSHS20 <: AbstractNLSModel
-  meta :: NLPModelMeta
-  nls_meta :: NLSMeta
+mutable struct NLSHS20{T, S} <: AbstractNLSModel{T, S}
+  meta :: NLPModelMeta{T, S}
+  nls_meta :: NLSMeta{T, S}
   counters :: NLSCounters
 end
 

--- a/src/nls/problems/nlslc.jl
+++ b/src/nls/problems/nlslc.jl
@@ -33,9 +33,9 @@ x_{15}^2 - 15^2
 
 Starting point: `zeros(15)`.
 """
-mutable struct NLSLC <: AbstractNLSModel
-  meta :: NLPModelMeta
-  nls_meta :: NLSMeta
+mutable struct NLSLC{T, S} <: AbstractNLSModel{T, S}
+  meta :: NLPModelMeta{T, S}
+  nls_meta :: NLSMeta{T, S}
   counters :: NLSCounters
 end
 

--- a/src/nls/problems/nlslc.jl
+++ b/src/nls/problems/nlslc.jl
@@ -39,12 +39,21 @@ mutable struct NLSLC{T, S} <: AbstractNLSModel{T, S}
   counters :: NLSCounters
 end
 
-function NLSLC()
-  meta = NLPModelMeta(15, nnzj=17, ncon=11, x0=zeros(15), lcon = [22.0; 1.0; -Inf; -11.0; -1.0; 1.0; -5.0; -6.0; -Inf * ones(3)], ucon=[22.0; Inf; 16.0; 9.0; -1.0; 1.0; Inf * ones(2); 1.0; 2.0; 3.0], name="NLSLINCON")
-  nls_meta = NLSMeta(15, 15, nnzj=15, nnzh=15)
+function NLSLC(::Type{T}) where T
+  meta = NLPModelMeta{T, Vector{T}}(
+    15,
+    nnzj=17,
+    ncon=11,
+    x0=zeros(T, 15),
+    lcon=T[22.0; 1.0; -Inf; -11.0; -1.0; 1.0; -5.0; -6.0; -Inf * ones(3)],
+    ucon=T[22.0; Inf; 16.0; 9.0; -1.0; 1.0; Inf * ones(2); 1.0; 2.0; 3.0],
+    name="NLSLINCON",
+  )
+  nls_meta = NLSMeta{T, Vector{T}}(15, 15, nnzj=15, nnzh=15)
 
   return NLSLC(meta, nls_meta, NLSCounters())
 end
+NLSLC() = NLSLC(Float64)
 
 function NLPModels.residual!(nls :: NLSLC, x :: AbstractVector, Fx :: AbstractVector)
   @lencheck 15 x Fx


### PR DESCRIPTION
Follows [NLPModels.jl PR #353](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/353) with parametric meta.

Should be merged after [NLPModelsModifiers.jl PR #12](https://github.com/JuliaSmoothOptimizers/NLPModelsModifiers.jl/pull/12).