### PR TITLE
Check dimension for linear API

### DIFF
--- a/src/nlp/problems/hs10.jl
+++ b/src/nlp/problems/hs10.jl
@@ -100,40 +100,40 @@ function NLPModels.hprod!(
   return Hv
 end
 
-function NLPModels.cons!(nlp::HS10, x::AbstractVector, cx::AbstractVector)
+function NLPModels.cons_nln!(nlp::HS10, x::AbstractVector, cx::AbstractVector)
   @lencheck 2 x
   @lencheck 1 cx
-  increment!(nlp, :neval_cons)
+  increment!(nlp, :neval_cons_nln)
   cx .= [-3 * x[1]^2 + 2 * x[1] * x[2] - x[2]^2 + 1]
   return cx
 end
 
-function NLPModels.jac_structure!(nlp::HS10, rows::AbstractVector{Int}, cols::AbstractVector{Int})
+function NLPModels.jac_nln_structure!(nlp::HS10, rows::AbstractVector{Int}, cols::AbstractVector{Int})
   @lencheck 2 rows cols
   rows .= [1, 1]
   cols .= [1, 2]
   return rows, cols
 end
 
-function NLPModels.jac_coord!(nlp::HS10, x::AbstractVector, vals::AbstractVector)
+function NLPModels.jac_nln_coord!(nlp::HS10, x::AbstractVector, vals::AbstractVector)
   @lencheck 2 x vals
-  increment!(nlp, :neval_jac)
+  increment!(nlp, :neval_jac_nln)
   vals .= [-6 * x[1] + 2 * x[2], 2 * x[1] - 2 * x[2]]
   return vals
 end
 
-function NLPModels.jprod!(nlp::HS10, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+function NLPModels.jprod_nln!(nlp::HS10, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
   @lencheck 2 x v
   @lencheck 1 Jv
-  increment!(nlp, :neval_jprod)
+  increment!(nlp, :neval_jprod_nln)
   Jv .= [(-6 * x[1] + 2 * x[2]) * v[1] + (2 * x[1] - 2 * x[2]) * v[2]]
   return Jv
 end
 
-function NLPModels.jtprod!(nlp::HS10, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
+function NLPModels.jtprod_nln!(nlp::HS10, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
   @lencheck 2 x Jtv
   @lencheck 1 v
-  increment!(nlp, :neval_jtprod)
+  increment!(nlp, :neval_jtprod_nln)
   Jtv .= [-6 * x[1] + 2 * x[2]; 2 * x[1] - 2 * x[2]] * v[1]
   return Jtv
 end

--- a/src/nlp/problems/hs11.jl
+++ b/src/nlp/problems/hs11.jl
@@ -100,40 +100,40 @@ function NLPModels.hprod!(
   return Hv
 end
 
-function NLPModels.cons!(nlp::HS11, x::AbstractVector, cx::AbstractVector)
+function NLPModels.cons_nln!(nlp::HS11, x::AbstractVector, cx::AbstractVector)
   @lencheck 2 x
   @lencheck 1 cx
-  increment!(nlp, :neval_cons)
+  increment!(nlp, :neval_cons_nln)
   cx .= [-x[1]^2 + x[2]]
   return cx
 end
 
-function NLPModels.jac_structure!(nlp::HS11, rows::AbstractVector{Int}, cols::AbstractVector{Int})
+function NLPModels.jac_nln_structure!(nlp::HS11, rows::AbstractVector{Int}, cols::AbstractVector{Int})
   @lencheck 2 rows cols
   rows .= [1, 1]
   cols .= [1, 2]
   return rows, cols
 end
 
-function NLPModels.jac_coord!(nlp::HS11, x::AbstractVector, vals::AbstractVector)
+function NLPModels.jac_nln_coord!(nlp::HS11, x::AbstractVector, vals::AbstractVector)
   @lencheck 2 x vals
-  increment!(nlp, :neval_jac)
+  increment!(nlp, :neval_jac_nln)
   vals .= [-2 * x[1], 1]
   return vals
 end
 
-function NLPModels.jprod!(nlp::HS11, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+function NLPModels.jprod_nln!(nlp::HS11, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
   @lencheck 2 x v
   @lencheck 1 Jv
-  increment!(nlp, :neval_jprod)
+  increment!(nlp, :neval_jprod_nln)
   Jv .= [-2 * x[1] * v[1] + v[2]]
   return Jv
 end
 
-function NLPModels.jtprod!(nlp::HS11, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
+function NLPModels.jtprod_nln!(nlp::HS11, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
   @lencheck 2 x Jtv
   @lencheck 1 v
-  increment!(nlp, :neval_jtprod)
+  increment!(nlp, :neval_jtprod_nln)
   Jtv .= [-2 * x[1]; 1] * v[1]
   return Jtv
 end

--- a/src/nlp/problems/hs13.jl
+++ b/src/nlp/problems/hs13.jl
@@ -116,37 +116,37 @@ function NLPModels.hprod!(
   return Hv
 end
 
-function NLPModels.cons!(nlp::HS13, x::AbstractVector, cx::AbstractVector)
+function NLPModels.cons_nln!(nlp::HS13, x::AbstractVector, cx::AbstractVector)
   @lencheck 2 x
   @lencheck 1 cx
-  increment!(nlp, :neval_cons)
+  increment!(nlp, :neval_cons_nln)
   cx .= [(1 - x[1])^3 - x[2]]
   return cx
 end
 
-function NLPModels.jac_structure!(nlp::HS13, rows::AbstractVector{Int}, cols::AbstractVector{Int})
+function NLPModels.jac_nln_structure!(nlp::HS13, rows::AbstractVector{Int}, cols::AbstractVector{Int})
   @lencheck 2 rows cols
   rows .= [1, 1]
   cols .= [1, 2]
   return rows, cols
 end
 
-function NLPModels.jac_coord!(nlp::HS13, x::AbstractVector{T}, vals::AbstractVector) where {T}
+function NLPModels.jac_nln_coord!(nlp::HS13, x::AbstractVector{T}, vals::AbstractVector) where {T}
   @lencheck 2 x vals
-  increment!(nlp, :neval_jac)
+  increment!(nlp, :neval_jac_nln)
   vals .= T[-3 * (1 - x[1])^2; -1]
   return vals
 end
 
-function NLPModels.jprod!(nlp::HS13, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+function NLPModels.jprod_nln!(nlp::HS13, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
   @lencheck 2 x v
   @lencheck 1 Jv
-  increment!(nlp, :neval_jprod)
+  increment!(nlp, :neval_jprod_nln)
   Jv .= (-3 * (1 - x[1])^2) * v[1] - v[2]
   return Jv
 end
 
-function NLPModels.jtprod!(
+function NLPModels.jtprod_nln!(
   nlp::HS13,
   x::AbstractVector{T},
   v::AbstractVector,
@@ -154,7 +154,7 @@ function NLPModels.jtprod!(
 ) where {T}
   @lencheck 2 x Jtv
   @lencheck 1 v
-  increment!(nlp, :neval_jtprod)
+  increment!(nlp, :neval_jtprod_nln)
   Jtv .= T[-3 * (1 - x[1])^2; -1] * v[1]
   return Jtv
 end

--- a/src/nlp/problems/hs6.jl
+++ b/src/nlp/problems/hs6.jl
@@ -97,41 +97,41 @@ function NLPModels.hprod!(
   return Hv
 end
 
-function NLPModels.cons!(nlp::HS6, x::AbstractVector, cx::AbstractVector)
+function NLPModels.cons_nln!(nlp::HS6, x::AbstractVector, cx::AbstractVector)
   @lencheck 2 x
   @lencheck 1 cx
-  increment!(nlp, :neval_cons)
+  increment!(nlp, :neval_cons_nln)
   cx[1] = 10 * (x[2] - x[1]^2)
   return cx
 end
 
-function NLPModels.jac_structure!(nlp::HS6, rows::AbstractVector{Int}, cols::AbstractVector{Int})
+function NLPModels.jac_nln_structure!(nlp::HS6, rows::AbstractVector{Int}, cols::AbstractVector{Int})
   @lencheck 2 rows cols
   rows[1:2] .= [1, 1]
   cols[1:2] .= [1, 2]
   return rows, cols
 end
 
-function NLPModels.jac_coord!(nlp::HS6, x::AbstractVector, vals::AbstractVector)
+function NLPModels.jac_nln_coord!(nlp::HS6, x::AbstractVector, vals::AbstractVector)
   @lencheck 2 x vals
-  increment!(nlp, :neval_jac)
+  increment!(nlp, :neval_jac_nln)
   vals[1] = -20 * x[1]
   vals[2] = 10
   return vals
 end
 
-function NLPModels.jprod!(nlp::HS6, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+function NLPModels.jprod_nln!(nlp::HS6, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
   @lencheck 2 x v
   @lencheck 1 Jv
-  increment!(nlp, :neval_jprod)
+  increment!(nlp, :neval_jprod_nln)
   Jv .= [-20 * x[1] * v[1] + 10 * v[2]]
   return Jv
 end
 
-function NLPModels.jtprod!(nlp::HS6, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
+function NLPModels.jtprod_nln!(nlp::HS6, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
   @lencheck 2 x Jtv
   @lencheck 1 v
-  increment!(nlp, :neval_jtprod)
+  increment!(nlp, :neval_jtprod_nln)
   Jtv .= [-20 * x[1]; 10] * v[1]
   return Jtv
 end

--- a/src/nls/problems/nlshs20.jl
+++ b/src/nls/problems/nlshs20.jl
@@ -140,15 +140,15 @@ function NLPModels.hprod_residual!(
   return Hiv
 end
 
-function NLPModels.cons!(nls::NLSHS20, x::AbstractVector, cx::AbstractVector)
+function NLPModels.cons_nln!(nls::NLSHS20, x::AbstractVector, cx::AbstractVector)
   @lencheck 2 x
   @lencheck 3 cx
-  increment!(nls, :neval_cons)
+  increment!(nls, :neval_cons_nln)
   cx .= [x[1] + x[2]^2; x[1]^2 + x[2]; x[1]^2 + x[2]^2 - 1]
   return cx
 end
 
-function NLPModels.jac_structure!(
+function NLPModels.jac_nln_structure!(
   nls::NLSHS20,
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
@@ -159,26 +159,26 @@ function NLPModels.jac_structure!(
   return rows, cols
 end
 
-function NLPModels.jac_coord!(nls::NLSHS20, x::AbstractVector, vals::AbstractVector)
+function NLPModels.jac_nln_coord!(nls::NLSHS20, x::AbstractVector, vals::AbstractVector)
   @lencheck 2 x
   @lencheck 6 vals
-  increment!(nls, :neval_jac)
+  increment!(nls, :neval_jac_nln)
   vals .= [1, 2x[2], 2x[1], 1, 2x[1], 2x[2]]
   return vals
 end
 
-function NLPModels.jprod!(nls::NLSHS20, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+function NLPModels.jprod_nln!(nls::NLSHS20, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
   @lencheck 2 x v
   @lencheck 3 Jv
-  increment!(nls, :neval_jprod)
+  increment!(nls, :neval_jprod_nln)
   Jv .= [v[1] + 2x[2] * v[2]; 2x[1] * v[1] + v[2]; 2x[1] * v[1] + 2x[2] * v[2]]
   return Jv
 end
 
-function NLPModels.jtprod!(nls::NLSHS20, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
+function NLPModels.jtprod_nln!(nls::NLSHS20, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
   @lencheck 2 x Jtv
   @lencheck 3 v
-  increment!(nls, :neval_jtprod)
+  increment!(nls, :neval_jtprod_nln)
   Jtv .= [v[1] + 2x[1] * (v[2] + v[3]); v[2] + 2x[2] * (v[1] + v[3])]
   return Jtv
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ addprocs(np - 1)
       consistent_nlps([nlp, nlp], exclude = [])
     end
     @testset "Check dimensions of problem $p" begin
-      check_nlp_dimensions(nlp, exclude = [])
+      check_nlp_dimensions(nlp, linear_api = true, exclude = [])
     end
     @testset "Multiple precision support of problem $p" begin
       multiple_precision_nlp(nlp_from_T, exclude = [])


### PR DESCRIPTION
#35 

packages implementing the linear API can activate this check by setting `linear_api = false`.