### PR TITLE
Add allocation tracker for NLPModels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.8.2"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/NLPModelsTest.jl
+++ b/src/NLPModelsTest.jl
@@ -1,7 +1,7 @@
 module NLPModelsTest
 
 #stdlib
-using LinearAlgebra, SparseArrays, Test
+using LinearAlgebra, Printf, SparseArrays, Test
 #jso
 using NLPModels, NLPModelsModifiers
 
@@ -25,5 +25,7 @@ for f in ["check-dimensions", "consistency", "multiple-precision", "view-subarra
   include("nls/$f.jl")
 end
 include("nlp/coord-memory.jl")
+
+include("allocs_model.jl")
 
 end

--- a/src/allocs_model.jl
+++ b/src/allocs_model.jl
@@ -1,0 +1,139 @@
+export test_allocs_nlpmodels, print_nlp_allocations
+
+"""
+    test_allocs_nlpmodels(nlp::AbstractNLPModel; exclude = [])
+
+Returns a `Dict` containing allocations of the in-place functions of NLPModel API.
+
+The keyword `exclude` takes a Array of Function to be excluded from the tests. Use `hess` (resp. `jac`) to exclude `hess_coord` and `hess_structure` (resp. `jac_coord` and `jac_structure`).
+"""
+function test_allocs_nlpmodels(nlp::AbstractNLPModel; exclude = [])
+  nlp_allocations = Dict(
+    :obj => NaN,
+    :grad! => NaN,
+    :hess_structure! => NaN,
+    :hess_coord! => NaN,
+    :hess_op! => NaN,
+    :hess_op_prod! => NaN,
+    :cons! => NaN,
+    :jac_structure! => NaN,
+    :jac_coord! => NaN,
+    :jac_op! => NaN,
+    :jac_op_prod! => NaN,
+    :jac_op_transpose_prod! => NaN,
+    :hess_lag_coord! => NaN,
+    :hess_lag_op! => NaN,
+    :hess_lag_op_prod! => NaN,
+  )
+
+  if !(obj in exclude)
+    x = get_x0(nlp)
+    obj(nlp, x)
+    nlp_allocations[:obj] = @allocated obj(nlp, x)
+  end
+  if !(grad in exclude)
+    x = get_x0(nlp)
+    g = similar(x)
+    grad!(nlp, x, g)
+    nlp_allocations[:grad!] = @allocated grad!(nlp, x, g)
+  end
+  if !(hess in exclude)
+    rows = Vector{Int}(undef, get_nnzh(nlp))
+    cols = Vector{Int}(undef, get_nnzh(nlp))
+    hess_structure!(nlp, rows, cols)
+    nlp_allocations[:hess_structure!] = @allocated hess_structure!(nlp, rows, cols)
+    x = get_x0(nlp)
+    vals = Vector{eltype(x)}(undef, get_nnzh(nlp))
+    hess_coord!(nlp, x, vals)
+    nlp_allocations[:hess_coord!] = @allocated hess_coord!(nlp, x, vals)
+    if get_ncon(nlp) > 0
+        y = get_y0(nlp)
+        hess_coord!(nlp, x, y, vals)
+        nlp_allocations[:hess_lag_coord!] = @allocated hess_coord!(nlp, x, y, vals)
+    end
+  end
+  if !(hess_op in exclude)
+    # First we test the definition of the operator
+    x = get_x0(nlp)
+    Hv = similar(x)
+    hess_op!(nlp, x, Hv)
+    nlp_allocations[:hess_op!] = @allocated hess_op!(nlp, x, Hv)
+    if get_ncon(nlp) > 0
+        y = get_y0(nlp)
+        hess_op!(nlp, x, y, Hv)
+        nlp_allocations[:hess_lag_op!] = @allocated hess_op!(nlp, x, y, Hv)
+    end
+    # Then, we test the product
+    v = copy(x)
+    H = hess_op!(nlp, x, Hv)
+    H * v
+    nlp_allocations[:hess_op_prod!] = @allocated H * v
+    if get_ncon(nlp) > 0
+        y = get_y0(nlp)
+        H = hess_op!(nlp, x, y, Hv)
+        H * v
+        nlp_allocations[:hess_lag_op_prod!] = @allocated H * v
+    end
+  end
+
+  if get_ncon(nlp) > 0 && !(cons in exclude)
+    x = get_x0(nlp)
+    c = Vector{eltype(x)}(undef, get_ncon(nlp))
+    cons!(nlp, x, c)
+    nlp_allocations[:cons!] = @allocated cons!(nlp, x, c)
+  end
+  if get_ncon(nlp) > 0 && !(jac in exclude)
+    rows = Vector{Int}(undef, get_nnzj(nlp))
+    cols = Vector{Int}(undef, get_nnzj(nlp))
+    jac_structure!(nlp, rows, cols)
+    nlp_allocations[:jac_structure!] = @allocated jac_structure!(nlp, rows, cols)
+    x = get_x0(nlp)
+    vals = Vector{eltype(x)}(undef, get_nnzj(nlp))
+    jac_coord!(nlp, x, vals)
+    nlp_allocations[:jac_coord!] = @allocated jac_coord!(nlp, x, vals)
+  end
+  if get_ncon(nlp) > 0 && !(jac_op in exclude)
+    # First we test the definition of the operator
+    x = get_x0(nlp)
+    Jtv = similar(x)
+    Jv = Vector{eltype(x)}(undef, get_ncon(nlp))
+    jac_op!(nlp, x, Jv, Jtv)
+    nlp_allocations[:jac_op!] = @allocated jac_op!(nlp, x, Jv, Jtv)
+
+    v = copy(x)
+    w = copy(get_y0(nlp))
+    J = jac_op!(nlp, x, Jv, Jtv)
+    J * v
+    nlp_allocations[:jac_op_prod!] = @allocated J * v
+    J' * w
+    nlp_allocations[:jac_op_transpose_prod!] = @allocated J' * w
+  end
+  return nlp_allocations
+end
+
+function NLPModels.histline(s, v, maxv)
+  @assert 0 ≤ v ≤ maxv
+  λ = maxv == 0 ? 0 : ceil(Int, 20 * v / maxv)
+  return @sprintf("%22s: %s %-6s", s, "█"^λ * "⋅"^(20 - λ), v)
+end
+
+"""
+print_nlp_allocations([io::IO = stdout], nlp::AbstractNLPModel, table::Dict)
+
+Print in a convenient way the result of `test_allocs_nlpmodels(nlp)`
+"""
+function print_nlp_allocations(nlp::AbstractNLPModel, table::Dict)
+  return print_nlp_allocations(stdout, nlp, table)
+end
+
+function print_nlp_allocations(io, nlp::AbstractNLPModel, table::Dict)
+    for k in keys(table)
+        if isnan(table[k])
+            pop!(table, k)
+        end
+    end
+    println(io, "  Problem name: $(get_name(nlp))")
+    lines = NLPModels.lines_of_hist(keys(table), values(table))
+    println(io, join(lines, "\n") * "\n")
+    return table
+end

--- a/src/allocs_model.jl
+++ b/src/allocs_model.jl
@@ -13,6 +13,7 @@ function test_allocs_nlpmodels(nlp::AbstractNLPModel; exclude = [])
     :grad! => NaN,
     :hess_structure! => NaN,
     :hess_coord! => NaN,
+    :hprod! => NaN,
     :hess_op! => NaN,
     :hess_op_prod! => NaN,
     :cons! => NaN,
@@ -22,6 +23,7 @@ function test_allocs_nlpmodels(nlp::AbstractNLPModel; exclude = [])
     :jac_op_prod! => NaN,
     :jac_op_transpose_prod! => NaN,
     :hess_lag_coord! => NaN,
+    :hprod_lag! => NaN,
     :hess_lag_op! => NaN,
     :hess_lag_op_prod! => NaN,
   )
@@ -50,6 +52,18 @@ function test_allocs_nlpmodels(nlp::AbstractNLPModel; exclude = [])
       y = get_y0(nlp)
       hess_coord!(nlp, x, y, vals)
       nlp_allocations[:hess_lag_coord!] = @allocated hess_coord!(nlp, x, y, vals)
+    end
+  end
+  if !(hprod in exclude)
+    x = get_x0(nlp)
+    v = copy(x)
+    Hv = similar(x)
+    hprod!(nlp, x, v, Hv)
+    nlp_allocations[:hprod!] = @allocated hprod!(nlp, x, v, Hv)
+    if get_ncon(nlp) > 0
+      y = get_y0(nlp)
+      hprod!(nlp, x, y, v, Hv)
+      nlp_allocations[:hprod_lag!] = @allocated hprod!(nlp, x, y, v, Hv)
     end
   end
   if !(hess_op in exclude)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,4 +50,8 @@ end
 pmap(nlp_tests, NLPModelsTest.nlp_problems)
 pmap(nls_tests, NLPModelsTest.nls_problems)
 
+io = IOBuffer();
+map(nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)), map(x -> eval(Symbol(x))(), NLPModelsTest.nlp_problems))
+map(nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)), map(x -> eval(Symbol(x))(), NLPModelsTest.nls_problems))
+
 rmprocs()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,9 +55,10 @@ map(
   nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)),
   map(x -> eval(Symbol(x))(), NLPModelsTest.nlp_problems),
 )
+print_nlp_allocations(io, LLS(), test_allocs_nlpmodels(LLS(), exclude = [hess]))
 map(
   nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)),
-  map(x -> eval(Symbol(x))(), NLPModelsTest.nls_problems),
+  map(x -> eval(Symbol(x))(), setdiff(NLPModelsTest.nls_problems, ["LLS"])),
 )
 
 rmprocs()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,13 @@ pmap(nlp_tests, NLPModelsTest.nlp_problems)
 pmap(nls_tests, NLPModelsTest.nls_problems)
 
 io = IOBuffer();
-map(nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)), map(x -> eval(Symbol(x))(), NLPModelsTest.nlp_problems))
-map(nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)), map(x -> eval(Symbol(x))(), NLPModelsTest.nls_problems))
+map(
+  nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)),
+  map(x -> eval(Symbol(x))(), NLPModelsTest.nlp_problems),
+)
+map(
+  nlp -> print_nlp_allocations(io, nlp, test_allocs_nlpmodels(nlp)),
+  map(x -> eval(Symbol(x))(), NLPModelsTest.nls_problems),
+)
 
 rmprocs()


### PR DESCRIPTION
This allows to test the allocations of the in-place NLPModel API
```
julia> using NLPModelsTest

julia> nlp = eval(Meta.parse(NLPModelsTest.nlp_problems[1]))()
BROWNDEN{Float64, Vector{Float64}}
  Problem name: BROWNDEN_manual
         All variables: ████████████████████ 4            All constraints: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                  free: ████████████████████ 4                       free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                 lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                      lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                 upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                      upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
               low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                    low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                 fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                      fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                     infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
            nnzh: (  0.00% sparsity)   10                    linear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                                                                nonlinear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                                                               nnzj: (------% sparsity)

  Counters:
                   obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                       grad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                       cons: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
              cons_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                   cons_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                       jcon: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                 jgrad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                        jac: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                    jac_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
               jac_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                      jprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                  jprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
             jprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                     jtprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 jtprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
            jtprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                       hess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                      hprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0
                 jhess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                     jhprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0


julia> print_nlp_allocations(nlp, test_allocs_nlpmodels(nlp))
  Problem name: BROWNDEN_manual
                   obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0
              hess_op!: █⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 2304.0
           hess_coord!: ████████████████████ 50976.0
                 grad!: █████████⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 21664.0
       hess_structure!: █⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 1888.0
         hess_op_prod!: █████████████⋅⋅⋅⋅⋅⋅⋅ 31456.0

Dict{Symbol, Float64} with 6 entries:
  :obj             => 0.0
  :hess_op!        => 2304.0
  :hess_coord!     => 50976.0
  :grad!           => 21664.0
  :hess_structure! => 1888.0
  :hess_op_prod!   => 31456.0

```