### PR TITLE
Import NLPModels `histline`

### DIFF
--- a/src/allocs_model.jl
+++ b/src/allocs_model.jl
@@ -321,6 +321,7 @@ function test_allocs_nlsmodels(nlp::AbstractNLSModel; exclude = [])
   return nlp_allocations
 end
 
+import NLPModels.histline
 function NLPModels.histline(s, v, maxv)
   @assert 0 ≤ v ≤ maxv
   λ = maxv == 0 ? 0 : ceil(Int, 20 * v / maxv)

--- a/src/allocs_model.jl
+++ b/src/allocs_model.jl
@@ -321,8 +321,7 @@ function test_allocs_nlsmodels(nlp::AbstractNLSModel; exclude = [])
   return nlp_allocations
 end
 
-import NLPModels.histline
-function NLPModels.histline(s, v, maxv)
+function NLPModels.histline(s::String, v::Integer, maxv::Integer)
   @assert 0 ≤ v ≤ maxv
   λ = maxv == 0 ? 0 : ceil(Int, 20 * v / maxv)
   return @sprintf("%31s: %s %-6s", s, "█"^λ * "⋅"^(20 - λ), v)


### PR DESCRIPTION
```
┌ NLPModelsTest [7998695d-6960-4d3a-85c4-e1bceb8cd856]
│  WARNING: Method definition histline(Any, Any, Any) in module NLPModels at /home/runner/.julia/packages/NLPModels/XBcWL/src/nlp/show.jl:29 overwritten in module NLPModelsTest at /home/runner/.julia/packages/NLPModelsTest/qCUnA/src/allocs_model.jl:324.
│    ** incremental compilation may be fatally broken for this module **
└  
```