### PR TITLE
Define test models with GPU compatible vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "7998695d-6960-4d3a-85c4-e1bceb8cd856"
 version = "0.9.2"
 
 [deps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"
@@ -17,7 +16,8 @@ NLPModelsModifiers = "0.6, 0.7"
 julia = "^1.6"
 
 [extras]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [targets]
-test = ["Distributed"]
+test = ["CUDA", "Distributed"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-NLPModels = "0.18, 0.19, 0.20, 0.21"
-NLPModelsModifiers = "0.6, 0.7"
+NLPModels = "0.21"
+NLPModelsModifiers = "0.7"
 julia = "^1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "7998695d-6960-4d3a-85c4-e1bceb8cd856"
 version = "0.9.2"
 
 [deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"

--- a/src/nlp/multiple-precision.jl
+++ b/src/nlp/multiple-precision.jl
@@ -54,7 +54,7 @@ function multiple_precision_nlp(
     if hess_coord ∉ exclude && hess_op ∉ exclude
       rows, cols = hess_structure(nlp)
       vals = hess_coord(nlp, x)
-      @test eltype(vals) == T
+      @test typeof(vals) == S
       Hv = fill!(S(undef, nlp.meta.nvar), 1)
       @test eltype(hess_op!(nlp, rows, cols, vals, Hv)) == T
     end
@@ -76,7 +76,7 @@ function multiple_precision_nlp(
       if jac_coord ∉ exclude && jac_op ∉ exclude
         rows, cols = jac_structure(nlp)
         vals = jac_coord(nlp, x)
-        @test eltype(vals) == T
+        @test typeof(vals) == S
         Av = fill!(S(undef, nlp.meta.ncon), 0)
         Atv = fill!(S(undef, nlp.meta.nvar), 0)
         @test eltype(jac_op!(nlp, rows, cols, vals, Av, Atv)) == T

--- a/src/nlp/multiple-precision.jl
+++ b/src/nlp/multiple-precision.jl
@@ -45,30 +45,31 @@ function multiple_precision_nlp(
 )
   for T in precisions
     nlp = nlp_from_T(T)
-    x = ones(T, nlp.meta.nvar)
+    S = typeof(nlp.meta.x0)
+    x = fill!(S(undef, nlp.meta.nvar), 1)
     @test obj ∈ exclude || typeof(obj(nlp, x)) == T
-    @test grad ∈ exclude || eltype(grad(nlp, x)) == T
+    @test grad ∈ exclude || typeof(grad(nlp, x)) == S
     @test hess ∈ exclude || eltype(hess(nlp, x)) == T
     @test hess_op ∈ exclude || eltype(hess_op(nlp, x)) == T
     if hess_coord ∉ exclude && hess_op ∉ exclude
       rows, cols = hess_structure(nlp)
       vals = hess_coord(nlp, x)
       @test eltype(vals) == T
-      Hv = zeros(T, nlp.meta.nvar)
+      Hv = fill!(S(undef, nlp.meta.nvar), 1)
       @test eltype(hess_op!(nlp, rows, cols, vals, Hv)) == T
     end
     if nlp.meta.ncon > 0
-      y = ones(T, nlp.meta.ncon)
-      @test cons ∈ exclude || eltype(cons(nlp, x)) == T
+      y = fill!(S(undef, nlp.meta.ncon), 1)
+      @test cons ∈ exclude || typeof(cons(nlp, x)) == S
       @test jac ∈ exclude || eltype(jac(nlp, x)) == T
       @test jac_op ∈ exclude || eltype(jac_op(nlp, x)) == T
       if linear_api && nlp.meta.nnln > 0
-        @test cons ∈ exclude || eltype(cons_nln(nlp, x)) == T
+        @test cons ∈ exclude || typeof(cons_nln(nlp, x)) == S
         @test jac ∈ exclude || eltype(jac_nln(nlp, x)) == T
         @test jac_op ∈ exclude || eltype(jac_nln_op(nlp, x)) == T
       end
       if linear_api && nlp.meta.nlin > 0
-        @test cons ∈ exclude || eltype(cons_lin(nlp, x)) == T
+        @test cons ∈ exclude || typeof(cons_lin(nlp, x)) == S
         @test jac ∈ exclude || eltype(jac_lin(nlp, x)) == T
         @test jac_op ∈ exclude || eltype(jac_lin_op(nlp, x)) == T
       end
@@ -76,23 +77,23 @@ function multiple_precision_nlp(
         rows, cols = jac_structure(nlp)
         vals = jac_coord(nlp, x)
         @test eltype(vals) == T
-        Av = zeros(T, nlp.meta.ncon)
-        Atv = zeros(T, nlp.meta.nvar)
+        Av = fill!(S(undef, nlp.meta.ncon), 0)
+        Atv = fill!(S(undef, nlp.meta.nvar), 0)
         @test eltype(jac_op!(nlp, rows, cols, vals, Av, Atv)) == T
         if linear_api && nlp.meta.nnln > 0
           rows, cols = jac_nln_structure(nlp)
           vals = jac_nln_coord(nlp, x)
-          @test eltype(vals) == T
-          Av = zeros(T, nlp.meta.nnln)
-          Atv = zeros(T, nlp.meta.nvar)
+          @test typeof(vals) == S
+          Av = fill!(S(undef, nlp.meta.nnln), 0)
+          Atv = fill!(S(undef, nlp.meta.nvar), 0)
           @test eltype(jac_nln_op!(nlp, rows, cols, vals, Av, Atv)) == T
         end
         if linear_api && nlp.meta.nlin > 0
           rows, cols = jac_lin_structure(nlp)
           vals = jac_lin_coord(nlp, x)
-          @test eltype(vals) == T
-          Av = zeros(T, nlp.meta.nlin)
-          Atv = zeros(T, nlp.meta.nvar)
+          @test typeof(vals) == S
+          Av = fill!(S(undef, nlp.meta.nlin), 0)
+          Atv = fill!(S(undef, nlp.meta.nvar), 0)
           @test eltype(jac_lin_op!(nlp, rows, cols, vals, Av, Atv)) == T
         end
       end
@@ -102,8 +103,8 @@ function multiple_precision_nlp(
       if hess_coord ∉ exclude && hess_op ∉ exclude
         rows, cols = hess_structure(nlp)
         vals = hess_coord(nlp, x, y)
-        @test eltype(vals) == T
-        Hv = zeros(T, nlp.meta.nvar)
+        @test typeof(vals) == S
+        Hv = fill!(S(undef, nlp.meta.nvar), 0)
         @test eltype(hess_op!(nlp, rows, cols, vals, Hv)) == T
       end
       @test jth_hess ∈ exclude || eltype(jth_hess(nlp, x, 1)) == T

--- a/src/nlp/multiple-precision.jl
+++ b/src/nlp/multiple-precision.jl
@@ -1,4 +1,4 @@
-export multiple_precision_nlp
+export multiple_precision_nlp, multiple_precision_nlp_array
 
 function multiple_precision_nlp(problem::String; kwargs...)
   Base.depwarn(
@@ -7,6 +7,24 @@ function multiple_precision_nlp(problem::String; kwargs...)
   )
   nlp_from_T = eval(Symbol(problem))
   multiple_precision_nlp(nlp_from_T; kwargs...)
+end
+
+"""
+    multiple_precision_nlp_array(nlp_from_T, ::Type{S}; precisions=[Float16, Float32, Float64])
+
+Check that the NLP API functions output type are the same as the input.
+It calls [`multiple_precision_nlp`](@ref) on problem type `T -> nlp_from_T(S(T))`.
+
+The array `precisions` are the tested floating point types.
+Note that `BigFloat` is not tested by default, because it is not supported by `CuArray`.
+"""
+function multiple_precision_nlp_array(
+  nlp_from_T,
+  ::Type{S};
+  precisions::Array = [Float16, Float32, Float64],
+  kwargs...,
+) where {S}
+  return multiple_precision_nlp(T -> nlp_from_T(S{T}), precisions = precisions; kwargs...)
 end
 
 """

--- a/src/nlp/problems/brownden.jl
+++ b/src/nlp/problems/brownden.jl
@@ -26,12 +26,14 @@ mutable struct BROWNDEN{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function BROWNDEN(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(4, x0 = T[25; 5; -5; -1], name = "BROWNDEN_manual", nnzh = 10)
+function BROWNDEN(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(4, x0 = S([25; 5; -5; -1]), name = "BROWNDEN_manual", nnzh = 10)
 
   return BROWNDEN(meta, Counters())
 end
 BROWNDEN() = BROWNDEN(Float64)
+BROWNDEN(::Type{S}) where {S <: AbstractVector} = BROWNDEN(eltype(S), S)
+BROWNDEN(::Type{T}) where {T} = BROWNDEN(T, Vector{T})
 
 function NLPModels.obj(nlp::BROWNDEN, x::AbstractVector{T}) where {T}
   @lencheck 4 x

--- a/src/nlp/problems/brownden.jl
+++ b/src/nlp/problems/brownden.jl
@@ -26,14 +26,12 @@ mutable struct BROWNDEN{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function BROWNDEN(::Type{T}, ::Type{S}) where {T, S}
-  meta = NLPModelMeta{T, S}(4, x0 = S([25; 5; -5; -1]), name = "BROWNDEN_manual", nnzh = 10)
-
+function BROWNDEN(::Type{S}) where {S}
+  meta = NLPModelMeta{eltype(S), S}(4, x0 = S([25; 5; -5; -1]), name = "BROWNDEN_manual", nnzh = 10)
   return BROWNDEN(meta, Counters())
 end
 BROWNDEN() = BROWNDEN(Float64)
-BROWNDEN(::Type{S}) where {S <: AbstractVector} = BROWNDEN(eltype(S), S)
-BROWNDEN(::Type{T}) where {T} = BROWNDEN(T, Vector{T})
+BROWNDEN(::Type{T}) where {T <: Number} = BROWNDEN(Vector{T})
 
 function NLPModels.obj(nlp::BROWNDEN, x::AbstractVector{T}) where {T}
   @lencheck 4 x

--- a/src/nlp/problems/hs10.jl
+++ b/src/nlp/problems/hs10.jl
@@ -19,21 +19,21 @@ mutable struct HS10{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS10(::Type{T}, ::Type{S}) where {T, S}
+function HS10(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     ncon = 1,
-    x0 = S(T[-10; 10]),
-    lcon = T[0],
-    ucon = T[Inf],
+    x0 = S([-10; 10]),
+    lcon = fill!(S(undef, 1), 0),
+    ucon = fill!(S(undef, 1), T(Inf)),
     name = "HS10_manual",
   )
 
   return HS10(meta, Counters())
 end
 HS10() = HS10(Float64)
-HS10(::Type{S}) where {S <: AbstractVector} = HS10(eltype(S), S)
-HS10(::Type{T}) where {T} = HS10(T, Vector{T})
+HS10(::Type{T}) where {T <: Number} = HS10(Vector{T})
 
 function NLPModels.obj(nlp::HS10, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs10.jl
+++ b/src/nlp/problems/hs10.jl
@@ -19,11 +19,11 @@ mutable struct HS10{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS10(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function HS10(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
     ncon = 1,
-    x0 = T[-10; 10],
+    x0 = S(T[-10; 10]),
     lcon = T[0],
     ucon = T[Inf],
     name = "HS10_manual",
@@ -32,6 +32,8 @@ function HS10(::Type{T}) where {T}
   return HS10(meta, Counters())
 end
 HS10() = HS10(Float64)
+HS10(::Type{S}) where {S <: AbstractVector} = HS10(eltype(S), S)
+HS10(::Type{T}) where {T} = HS10(T, Vector{T})
 
 function NLPModels.obj(nlp::HS10, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs11.jl
+++ b/src/nlp/problems/hs11.jl
@@ -19,23 +19,23 @@ mutable struct HS11{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS11(::Type{T}, ::Type{S}) where {T, S}
+function HS11(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     ncon = 1,
     nnzh = 2,
     nnzj = 2,
-    x0 = S(T[4.9; 0.1]),
-    lcon = T[0],
-    ucon = T[Inf],
+    x0 = S([49 // 10; 1 // 10]),
+    lcon = fill!(S(undef, 1), 0),
+    ucon = fill!(S(undef, 1), T(Inf)),
     name = "HS11_manual",
   )
 
   return HS11(meta, Counters())
 end
 HS11() = HS11(Float64)
-HS11(::Type{S}) where {S <: AbstractVector} = HS11(eltype(S), S)
-HS11(::Type{T}) where {T} = HS11(T, Vector{T})
+HS11(::Type{T}) where {T <: Number} = HS11(Vector{T})
 
 function NLPModels.obj(nlp::HS11, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs11.jl
+++ b/src/nlp/problems/hs11.jl
@@ -19,13 +19,13 @@ mutable struct HS11{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS11(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function HS11(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
     ncon = 1,
     nnzh = 2,
     nnzj = 2,
-    x0 = T[4.9; 0.1],
+    x0 = S(T[4.9; 0.1]),
     lcon = T[0],
     ucon = T[Inf],
     name = "HS11_manual",
@@ -34,6 +34,8 @@ function HS11(::Type{T}) where {T}
   return HS11(meta, Counters())
 end
 HS11() = HS11(Float64)
+HS11(::Type{S}) where {S <: AbstractVector} = HS11(eltype(S), S)
+HS11(::Type{T}) where {T} = HS11(T, Vector{T})
 
 function NLPModels.obj(nlp::HS11, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs13.jl
+++ b/src/nlp/problems/hs13.jl
@@ -21,15 +21,16 @@ mutable struct HS13{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS13(::Type{T}, ::Type{S}) where {T, S}
+function HS13(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     ncon = 1,
     x0 = S([-2; -2]),
-    lvar = zeros(T, 2),
-    uvar = T(Inf) * ones(T, 2),
-    lcon = T[0],
-    ucon = T[Inf],
+    lvar = fill!(S(undef, 2), 0),
+    uvar = fill!(S(undef, 2), T(Inf)),
+    lcon = fill!(S(undef, 1), 0),
+    ucon = fill!(S(undef, 1), T(Inf)),
     name = "HS13_manual",
     nnzh = 2,
   )
@@ -37,8 +38,7 @@ function HS13(::Type{T}, ::Type{S}) where {T, S}
   return HS13(meta, Counters())
 end
 HS13() = HS13(Float64)
-HS13(::Type{S}) where {S <: AbstractVector} = HS13(eltype(S), S)
-HS13(::Type{T}) where {T} = HS13(T, Vector{T})
+HS13(::Type{T}) where {T <: Number} = HS13(Vector{T})
 
 function NLPModels.obj(nlp::HS13, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs13.jl
+++ b/src/nlp/problems/hs13.jl
@@ -21,11 +21,11 @@ mutable struct HS13{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS13(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function HS13(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
     ncon = 1,
-    x0 = T[-2; -2],
+    x0 = S([-2; -2]),
     lvar = zeros(T, 2),
     uvar = T(Inf) * ones(T, 2),
     lcon = T[0],
@@ -37,6 +37,8 @@ function HS13(::Type{T}) where {T}
   return HS13(meta, Counters())
 end
 HS13() = HS13(Float64)
+HS13(::Type{S}) where {S <: AbstractVector} = HS13(eltype(S), S)
+HS13(::Type{T}) where {T} = HS13(T, Vector{T})
 
 function NLPModels.obj(nlp::HS13, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs14.jl
+++ b/src/nlp/problems/hs14.jl
@@ -20,12 +20,12 @@ mutable struct HS14{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS14(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function HS14(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
     nnzh = 2,
     ncon = 2,
-    x0 = T[2; 2],
+    x0 = S([2; 2]),
     lcon = T[-1; 0],
     ucon = T[-1; Inf],
     name = "HS14_manual",
@@ -37,6 +37,8 @@ function HS14(::Type{T}) where {T}
   return HS14(meta, Counters())
 end
 HS14() = HS14(Float64)
+HS14(::Type{S}) where {S <: AbstractVector} = HS14(eltype(S), S)
+HS14(::Type{T}) where {T} = HS14(T, Vector{T})
 
 function NLPModels.obj(nlp::HS14, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs14.jl
+++ b/src/nlp/problems/hs14.jl
@@ -20,14 +20,15 @@ mutable struct HS14{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS14(::Type{T}, ::Type{S}) where {T, S}
+function HS14(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     nnzh = 2,
     ncon = 2,
     x0 = S([2; 2]),
-    lcon = T[-1; 0],
-    ucon = T[-1; Inf],
+    lcon = S([-1; 0]),
+    ucon = S([-1; T(Inf)]),
     name = "HS14_manual",
     lin = 1:1,
     lin_nnzj = 2,
@@ -37,8 +38,7 @@ function HS14(::Type{T}, ::Type{S}) where {T, S}
   return HS14(meta, Counters())
 end
 HS14() = HS14(Float64)
-HS14(::Type{S}) where {S <: AbstractVector} = HS14(eltype(S), S)
-HS14(::Type{T}) where {T} = HS14(T, Vector{T})
+HS14(::Type{T}) where {T <: Number} = HS14(Vector{T})
 
 function NLPModels.obj(nlp::HS14, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs5.jl
+++ b/src/nlp/problems/hs5.jl
@@ -20,10 +20,10 @@ mutable struct HS5{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS5(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function HS5(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
-    x0 = zeros(T, 2),
+    x0 = fill!(S(undef, 2), 0),
     lvar = T[-1.5; -3],
     uvar = T[4; 3],
     name = "HS5_manual",
@@ -32,6 +32,8 @@ function HS5(::Type{T}) where {T}
   return HS5(meta, Counters())
 end
 HS5() = HS5(Float64)
+HS5(::Type{S}) where {S <: AbstractVector} = HS5(eltype(S), S)
+HS5(::Type{T}) where {T} = HS5(T, Vector{T})
 
 function NLPModels.obj(nlp::HS5, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs5.jl
+++ b/src/nlp/problems/hs5.jl
@@ -20,20 +20,18 @@ mutable struct HS5{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS5(::Type{T}, ::Type{S}) where {T, S}
-  meta = NLPModelMeta{T, S}(
+function HS5(::Type{S}) where {S}
+  meta = NLPModelMeta{eltype(S), S}(
     2,
     x0 = fill!(S(undef, 2), 0),
-    lvar = T[-1.5; -3],
-    uvar = T[4; 3],
+    lvar = S([-15 // 10; -3]),
+    uvar = S([4; 3]),
     name = "HS5_manual",
   )
-
   return HS5(meta, Counters())
 end
 HS5() = HS5(Float64)
-HS5(::Type{S}) where {S <: AbstractVector} = HS5(eltype(S), S)
-HS5(::Type{T}) where {T} = HS5(T, Vector{T})
+HS5(::Type{T}) where {T <: Number} = HS5(Vector{T})
 
 function NLPModels.obj(nlp::HS5, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs6.jl
+++ b/src/nlp/problems/hs6.jl
@@ -19,13 +19,13 @@ mutable struct HS6{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS6(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function HS6(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
     ncon = 1,
     nnzh = 1,
     nnzj = 2,
-    x0 = T[-1.2; 1],
+    x0 = S(T[-1.2; 1]),
     lcon = T[0],
     ucon = T[0],
     name = "HS6_manual",
@@ -34,6 +34,8 @@ function HS6(::Type{T}) where {T}
   return HS6(meta, Counters())
 end
 HS6() = HS6(Float64)
+HS6(::Type{S}) where {S <: AbstractVector} = HS6(eltype(S), S)
+HS6(::Type{T}) where {T} = HS6(T, Vector{T})
 
 function NLPModels.obj(nlp::HS6, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/hs6.jl
+++ b/src/nlp/problems/hs6.jl
@@ -19,23 +19,22 @@ mutable struct HS6{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function HS6(::Type{T}, ::Type{S}) where {T, S}
-  meta = NLPModelMeta{T, S}(
+function HS6(::Type{S}) where {S}
+  meta = NLPModelMeta{eltype(S), S}(
     2,
     ncon = 1,
     nnzh = 1,
     nnzj = 2,
-    x0 = S(T[-1.2; 1]),
-    lcon = T[0],
-    ucon = T[0],
+    x0 = S([-12 // 10; 1]),
+    lcon = fill!(S(undef, 1), 0),
+    ucon = fill!(S(undef, 1), 0),
     name = "HS6_manual",
   )
 
   return HS6(meta, Counters())
 end
 HS6() = HS6(Float64)
-HS6(::Type{S}) where {S <: AbstractVector} = HS6(eltype(S), S)
-HS6(::Type{T}) where {T} = HS6(T, Vector{T})
+HS6(::Type{T}) where {T <: Number} = HS6(Vector{T})
 
 function NLPModels.obj(nlp::HS6, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/lincon.jl
+++ b/src/nlp/problems/lincon.jl
@@ -29,13 +29,13 @@ mutable struct LINCON{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function LINCON(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function LINCON(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     15,
     nnzh = 15,
     nnzj = 17,
     ncon = 11,
-    x0 = zeros(T, 15),
+    x0 = fill!(S(undef, 15), 0),
     lcon = T[22; 1; -Inf; -11; -1; 1; -5; -6; -Inf * ones(3)],
     ucon = T[22; Inf; 16; 9; -1; 1; Inf * ones(2); 1; 2; 3],
     name = "LINCON_manual",
@@ -47,6 +47,8 @@ function LINCON(::Type{T}) where {T}
   return LINCON(meta, Counters())
 end
 LINCON() = LINCON(Float64)
+LINCON(::Type{S}) where {S <: AbstractVector} = LINCON(eltype(S), S)
+LINCON(::Type{T}) where {T} = LINCON(T, Vector{T})
 
 function NLPModels.obj(nlp::LINCON, x::AbstractVector)
   @lencheck 15 x

--- a/src/nlp/problems/lincon.jl
+++ b/src/nlp/problems/lincon.jl
@@ -29,15 +29,16 @@ mutable struct LINCON{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function LINCON(::Type{T}, ::Type{S}) where {T, S}
+function LINCON(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     15,
     nnzh = 15,
     nnzj = 17,
     ncon = 11,
     x0 = fill!(S(undef, 15), 0),
-    lcon = T[22; 1; -Inf; -11; -1; 1; -5; -6; -Inf * ones(3)],
-    ucon = T[22; Inf; 16; 9; -1; 1; Inf * ones(2); 1; 2; 3],
+    lcon = S([22; 1; -T(Inf); -11; -1; 1; -5; -6; -T(Inf) * ones(T, 3)]),
+    ucon = S([22; T(Inf); 16; 9; -1; 1; T(Inf) * ones(T, 2); 1; 2; 3]),
     name = "LINCON_manual",
     lin = 1:11,
     lin_nnzj = 17,
@@ -47,8 +48,7 @@ function LINCON(::Type{T}, ::Type{S}) where {T, S}
   return LINCON(meta, Counters())
 end
 LINCON() = LINCON(Float64)
-LINCON(::Type{S}) where {S <: AbstractVector} = LINCON(eltype(S), S)
-LINCON(::Type{T}) where {T} = LINCON(T, Vector{T})
+LINCON(::Type{T}) where {T <: Number} = LINCON(Vector{T})
 
 function NLPModels.obj(nlp::LINCON, x::AbstractVector)
   @lencheck 15 x

--- a/src/nlp/problems/linsv.jl
+++ b/src/nlp/problems/linsv.jl
@@ -20,13 +20,13 @@ mutable struct LINSV{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function LINSV(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function LINSV(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
     nnzh = 0,
     nnzj = 3,
     ncon = 2,
-    x0 = zeros(T, 2),
+    x0 = fill!(S(undef, 2), 0),
     lcon = T[3; 1],
     ucon = T[Inf; Inf],
     name = "LINSV_manual",
@@ -38,6 +38,8 @@ function LINSV(::Type{T}) where {T}
   return LINSV(meta, Counters())
 end
 LINSV() = LINSV(Float64)
+LINSV(::Type{S}) where {S <: AbstractVector} = LINSV(eltype(S), S)
+LINSV(::Type{T}) where {T} = LINSV(T, Vector{T})
 
 function NLPModels.obj(nlp::LINSV, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/linsv.jl
+++ b/src/nlp/problems/linsv.jl
@@ -20,15 +20,16 @@ mutable struct LINSV{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function LINSV(::Type{T}, ::Type{S}) where {T, S}
+function LINSV(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     nnzh = 0,
     nnzj = 3,
     ncon = 2,
     x0 = fill!(S(undef, 2), 0),
-    lcon = T[3; 1],
-    ucon = T[Inf; Inf],
+    lcon = S([3; 1]),
+    ucon = S([T(Inf); T(Inf)]),
     name = "LINSV_manual",
     lin = 1:2,
     lin_nnzj = 3,
@@ -38,8 +39,7 @@ function LINSV(::Type{T}, ::Type{S}) where {T, S}
   return LINSV(meta, Counters())
 end
 LINSV() = LINSV(Float64)
-LINSV(::Type{S}) where {S <: AbstractVector} = LINSV(eltype(S), S)
-LINSV(::Type{T}) where {T} = LINSV(T, Vector{T})
+LINSV(::Type{T}) where {T <: Number} = LINSV(Vector{T})
 
 function NLPModels.obj(nlp::LINSV, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/mgh01feas.jl
+++ b/src/nlp/problems/mgh01feas.jl
@@ -25,10 +25,10 @@ mutable struct MGH01Feas{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function MGH01Feas(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function MGH01Feas(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
-    x0 = T[-1.2; 1.0],
+    x0 = S([-12 // 10; 1]),
     name = "MGH01Feas_manual",
     ncon = 2,
     lcon = T[1; 0],
@@ -43,6 +43,8 @@ function MGH01Feas(::Type{T}) where {T}
   return MGH01Feas(meta, Counters())
 end
 MGH01Feas() = MGH01Feas(Float64)
+MGH01Feas(::Type{S}) where {S <: AbstractVector} = MGH01Feas(eltype(S), S)
+MGH01Feas(::Type{T}) where {T} = MGH01Feas(T, Vector{T})
 
 function NLPModels.obj(nlp::MGH01Feas, x::AbstractVector)
   @lencheck 2 x

--- a/src/nlp/problems/mgh01feas.jl
+++ b/src/nlp/problems/mgh01feas.jl
@@ -25,14 +25,14 @@ mutable struct MGH01Feas{T, S} <: AbstractNLPModel{T, S}
   counters::Counters
 end
 
-function MGH01Feas(::Type{T}, ::Type{S}) where {T, S}
-  meta = NLPModelMeta{T, S}(
+function MGH01Feas(::Type{S}) where {S}
+  meta = NLPModelMeta{eltype(S), S}(
     2,
     x0 = S([-12 // 10; 1]),
     name = "MGH01Feas_manual",
     ncon = 2,
-    lcon = T[1; 0],
-    ucon = T[1; 0],
+    lcon = S([1; 0]),
+    ucon = S([1; 0]),
     nnzj = 3,
     nnzh = 1,
     lin = 1:1,
@@ -43,8 +43,7 @@ function MGH01Feas(::Type{T}, ::Type{S}) where {T, S}
   return MGH01Feas(meta, Counters())
 end
 MGH01Feas() = MGH01Feas(Float64)
-MGH01Feas(::Type{S}) where {S <: AbstractVector} = MGH01Feas(eltype(S), S)
-MGH01Feas(::Type{T}) where {T} = MGH01Feas(T, Vector{T})
+MGH01Feas(::Type{T}) where {T <: Number} = MGH01Feas(Vector{T})
 
 function NLPModels.obj(nlp::MGH01Feas, x::AbstractVector)
   @lencheck 2 x

--- a/src/nls/multiple-precision.jl
+++ b/src/nls/multiple-precision.jl
@@ -1,4 +1,4 @@
-export multiple_precision_nls
+export multiple_precision_nls, multiple_precision_nls_array
 
 function multiple_precision_nls(problem::String; kwargs...)
   Base.depwarn(
@@ -7,6 +7,24 @@ function multiple_precision_nls(problem::String; kwargs...)
   )
   nls_from_T = eval(Symbol(problem))
   multiple_precision_nls(nls_from_T; kwargs...)
+end
+
+"""
+    multiple_precision_nls_array(nlp_from_T, ::Type{S}; precisions=[Float16, Float32, Float64])
+
+Check that the NLS API functions output type are the same as the input.
+It calls [`multiple_precision_nls`](@ref) on problem type `T -> nlp_from_T(S(T))`.
+
+The array `precisions` are the tested floating point types.
+Note that `BigFloat` is not tested by default, because it is not supported by `CuArray`.
+"""
+function multiple_precision_nls_array(
+  nlp_from_T,
+  ::Type{S};
+  precisions::Array = [Float16, Float32, Float64],
+  kwargs...,
+) where {S}
+  return multiple_precision_nls(T -> nlp_from_T(S{T}), precisions = precisions; kwargs...)
 end
 
 """

--- a/src/nls/multiple-precision.jl
+++ b/src/nls/multiple-precision.jl
@@ -45,16 +45,17 @@ function multiple_precision_nls(
 )
   for T in precisions
     nls = nls_from_T(T)
-    x = ones(T, nls.meta.nvar)
-    @test residual ∈ exclude || eltype(residual(nls, x)) == T
+    S = typeof(nls.meta.x0)
+    x = fill!(S(undef, nls.meta.nvar), 1)
+    @test residual ∈ exclude || typeof(residual(nls, x)) == S
     @test jac_residual ∈ exclude || eltype(jac_residual(nls, x)) == T
     @test jac_op_residual ∈ exclude || eltype(jac_op_residual(nls, x)) == T
     if jac_coord_residual ∉ exclude && jac_op_residual ∉ exclude
       rows, cols = jac_structure_residual(nls)
       vals = jac_coord_residual(nls, x)
-      @test eltype(vals) == T
-      Av = zeros(T, nls.nls_meta.nequ)
-      Atv = zeros(T, nls.meta.nvar)
+      @test typeof(vals) == S
+      Av = fill!(S(undef, nls.meta.ncon), 0)
+      Atv = fill!(S(undef, nls.meta.nvar), 0)
       @test eltype(jac_op_residual!(nls, rows, cols, vals, Av, Atv)) == T
     end
     @test hess_residual ∈ exclude || eltype(hess_residual(nls, x, ones(T, nls.nls_meta.nequ))) == T
@@ -64,42 +65,42 @@ function multiple_precision_nls(
       end
     end
     @test obj ∈ exclude || typeof(obj(nls, x)) == T
-    @test grad ∈ exclude || eltype(grad(nls, x)) == T
+    @test grad ∈ exclude || typeof(grad(nls, x)) == S
     if nls.meta.ncon > 0
-      @test cons ∈ exclude || eltype(cons(nls, x)) == T
+      @test cons ∈ exclude || typeof(cons(nls, x)) == S
       @test jac ∈ exclude || eltype(jac(nls, x)) == T
       @test jac_op ∈ exclude || eltype(jac_op(nls, x)) == T
       if linear_api && nls.meta.nnln > 0
-        @test cons ∈ exclude || eltype(cons_nln(nls, x)) == T
+        @test cons ∈ exclude || typeof(cons_nln(nls, x)) == S
         @test jac ∈ exclude || eltype(jac_nln(nls, x)) == T
         @test jac_op ∈ exclude || eltype(jac_nln_op(nls, x)) == T
       end
       if linear_api && nls.meta.nlin > 0
-        @test cons ∈ exclude || eltype(cons_lin(nls, x)) == T
+        @test cons ∈ exclude || typeof(cons_lin(nls, x)) == S
         @test jac ∈ exclude || eltype(jac_lin(nls, x)) == T
         @test jac_op ∈ exclude || eltype(jac_lin_op(nls, x)) == T
       end
       if jac_coord ∉ exclude && jac_op ∉ exclude
         rows, cols = jac_structure(nls)
         vals = jac_coord(nls, x)
-        @test eltype(vals) == T
-        Av = zeros(T, nls.meta.ncon)
-        Atv = zeros(T, nls.meta.nvar)
+        @test typeof(vals) == S
+        Av = fill!(S(undef, nls.meta.ncon), 0)
+        Atv = fill!(S(undef, nls.meta.nvar), 0)
         @test eltype(jac_op!(nls, rows, cols, vals, Av, Atv)) == T
         if linear_api && nls.meta.nnln > 0
           rows, cols = jac_nln_structure(nls)
           vals = jac_nln_coord(nls, x)
-          @test eltype(vals) == T
-          Av = zeros(T, nls.meta.nnln)
-          Atv = zeros(T, nls.meta.nvar)
+          @test typeof(vals) == S
+          Av = fill!(S(undef, nls.meta.nnln), 0)
+          Atv = fill!(S(undef, nls.meta.nvar), 0)
           @test eltype(jac_nln_op!(nls, rows, cols, vals, Av, Atv)) == T
         end
         if linear_api && nls.meta.nlin > 0
           rows, cols = jac_lin_structure(nls)
           vals = jac_lin_coord(nls, x)
-          @test eltype(vals) == T
-          Av = zeros(T, nls.meta.nlin)
-          Atv = zeros(T, nls.meta.nvar)
+          @test typeof(vals) == S
+          Av = fill!(S(undef, nls.meta.nlin), 0)
+          Atv = fill!(S(undef, nls.meta.nvar), 0)
           @test eltype(jac_lin_op!(nls, rows, cols, vals, Av, Atv)) == T
         end
       end

--- a/src/nls/multiple-precision.jl
+++ b/src/nls/multiple-precision.jl
@@ -54,7 +54,7 @@ function multiple_precision_nls(
       rows, cols = jac_structure_residual(nls)
       vals = jac_coord_residual(nls, x)
       @test typeof(vals) == S
-      Av = fill!(S(undef, nls.meta.ncon), 0)
+      Av = fill!(S(undef, nls.nls_meta.nequ), 0)
       Atv = fill!(S(undef, nls.meta.nvar), 0)
       @test eltype(jac_op_residual!(nls, rows, cols, vals, Av, Atv)) == T
     end

--- a/src/nls/problems/bndrosenbrock.jl
+++ b/src/nls/problems/bndrosenbrock.jl
@@ -28,19 +28,21 @@ mutable struct BNDROSENBROCK{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function BNDROSENBROCK(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function BNDROSENBROCK(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
-    x0 = T[-1.2; 1],
-    lvar = T[-1; -2],
-    uvar = T[0.8; 2],
+    x0 = S([-12 // 10; 1]),
+    lvar = S([-1; -2]),
+    uvar = S([8 // 10; 2]),
     name = "BNDROSENBROCK_manual",
   )
-  nls_meta = NLSMeta{T, Vector{T}}(2, 2, nnzj = 3, nnzh = 1)
+  nls_meta = NLSMeta{T, S}(2, 2, nnzj = 3, nnzh = 1)
 
   return BNDROSENBROCK(meta, nls_meta, NLSCounters())
 end
 BNDROSENBROCK() = BNDROSENBROCK(Float64)
+BNDROSENBROCK(::Type{S}) where {S <: AbstractVector} = BNDROSENBROCK(eltype(S), S)
+BNDROSENBROCK(::Type{T}) where {T} = BNDROSENBROCK(T, Vector{T})
 
 function NLPModels.residual!(nls::BNDROSENBROCK, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/bndrosenbrock.jl
+++ b/src/nls/problems/bndrosenbrock.jl
@@ -28,7 +28,8 @@ mutable struct BNDROSENBROCK{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function BNDROSENBROCK(::Type{T}, ::Type{S}) where {T, S}
+function BNDROSENBROCK(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     x0 = S([-12 // 10; 1]),
@@ -41,8 +42,7 @@ function BNDROSENBROCK(::Type{T}, ::Type{S}) where {T, S}
   return BNDROSENBROCK(meta, nls_meta, NLSCounters())
 end
 BNDROSENBROCK() = BNDROSENBROCK(Float64)
-BNDROSENBROCK(::Type{S}) where {S <: AbstractVector} = BNDROSENBROCK(eltype(S), S)
-BNDROSENBROCK(::Type{T}) where {T} = BNDROSENBROCK(T, Vector{T})
+BNDROSENBROCK(::Type{T}) where {T <: Number} = BNDROSENBROCK(Vector{T})
 
 function NLPModels.residual!(nls::BNDROSENBROCK, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/lls.jl
+++ b/src/nls/problems/lls.jl
@@ -28,7 +28,8 @@ mutable struct LLS{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function LLS(::Type{T}, ::Type{S}) where {T, S}
+function LLS(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     x0 = fill!(S(undef, 2), 0),
@@ -47,8 +48,7 @@ function LLS(::Type{T}, ::Type{S}) where {T, S}
   return LLS(meta, nls_meta, NLSCounters())
 end
 LLS() = LLS(Float64)
-LLS(::Type{S}) where {S <: AbstractVector} = LLS(eltype(S), S)
-LLS(::Type{T}) where {T} = LLS(T, Vector{T})
+LLS(::Type{T}) where {T <: Number} = LLS(Vector{T})
 
 function NLPModels.residual!(nls::LLS, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x

--- a/src/nls/problems/lls.jl
+++ b/src/nls/problems/lls.jl
@@ -28,25 +28,27 @@ mutable struct LLS{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function LLS(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function LLS(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
-    x0 = zeros(T, 2),
+    x0 = fill!(S(undef, 2), 0),
     name = "LLS_manual",
     ncon = 1,
-    lcon = T[0.0],
-    ucon = T[Inf],
+    lcon = S([0]),
+    ucon = S([T(Inf)]),
     nnzj = 2,
     nnzh = 2,
     lin = 1:1,
     lin_nnzj = 2,
     nln_nnzj = 0,
   )
-  nls_meta = NLSMeta{T, Vector{T}}(3, 2, nnzj = 5, nnzh = 0)
+  nls_meta = NLSMeta{T, S}(3, 2, nnzj = 5, nnzh = 0)
 
   return LLS(meta, nls_meta, NLSCounters())
 end
 LLS() = LLS(Float64)
+LLS(::Type{S}) where {S <: AbstractVector} = LLS(eltype(S), S)
+LLS(::Type{T}) where {T} = LLS(T, Vector{T})
 
 function NLPModels.residual!(nls::LLS, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x

--- a/src/nls/problems/mgh01.jl
+++ b/src/nls/problems/mgh01.jl
@@ -33,15 +33,15 @@ mutable struct MGH01{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function MGH01(::Type{T}, ::Type{S}) where {T, S}
+function MGH01(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(2, x0 = S([-12 // 10; 1]), name = "MGH01_manual")
   nls_meta = NLSMeta{T, S}(2, 2, nnzj = 3, nnzh = 1)
 
   return MGH01(meta, nls_meta, NLSCounters())
 end
 MGH01() = MGH01(Float64)
-MGH01(::Type{S}) where {S <: AbstractVector} = MGH01(eltype(S), S)
-MGH01(::Type{T}) where {T} = MGH01(T, Vector{T})
+MGH01(::Type{T}) where {T <: Number} = MGH01(Vector{T})
 
 function NLPModels.residual!(nls::MGH01, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/mgh01.jl
+++ b/src/nls/problems/mgh01.jl
@@ -33,13 +33,15 @@ mutable struct MGH01{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function MGH01(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(2, x0 = T[-1.2; 1], name = "MGH01_manual")
-  nls_meta = NLSMeta{T, Vector{T}}(2, 2, nnzj = 3, nnzh = 1)
+function MGH01(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(2, x0 = S([-12 // 10; 1]), name = "MGH01_manual")
+  nls_meta = NLSMeta{T, S}(2, 2, nnzj = 3, nnzh = 1)
 
   return MGH01(meta, nls_meta, NLSCounters())
 end
 MGH01() = MGH01(Float64)
+MGH01(::Type{S}) where {S <: AbstractVector} = MGH01(eltype(S), S)
+MGH01(::Type{T}) where {T} = MGH01(T, Vector{T})
 
 function NLPModels.residual!(nls::MGH01, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/nlshs20.jl
+++ b/src/nls/problems/nlshs20.jl
@@ -30,23 +30,25 @@ mutable struct NLSHS20{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function NLSHS20(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function NLSHS20(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     2,
-    x0 = T[-2.0; 1.0],
+    x0 = S([-2; 1]),
     name = "NLSHS20_manual",
-    lvar = T[-0.5; -Inf],
-    uvar = T[0.5; Inf],
+    lvar = S([-1 // 2; -T(Inf)]),
+    uvar = S([1 // 2; T(Inf)]),
     ncon = 3,
-    lcon = zeros(T, 3),
-    ucon = fill(T(Inf), 3),
+    lcon = fill!(S(undef, 3), 0),
+    ucon = fill!(S(undef, 3), T(Inf)),
     nnzj = 6,
   )
-  nls_meta = NLSMeta{T, Vector{T}}(2, 2, nnzj = 3, nnzh = 1)
+  nls_meta = NLSMeta{T, S}(2, 2, nnzj = 3, nnzh = 1)
 
   return NLSHS20(meta, nls_meta, NLSCounters())
 end
 NLSHS20() = NLSHS20(Float64)
+NLSHS20(::Type{S}) where {S <: AbstractVector} = NLSHS20(eltype(S), S)
+NLSHS20(::Type{T}) where {T} = NLSHS20(T, Vector{T})
 
 function NLPModels.residual!(nls::NLSHS20, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/nlshs20.jl
+++ b/src/nls/problems/nlshs20.jl
@@ -30,7 +30,8 @@ mutable struct NLSHS20{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function NLSHS20(::Type{T}, ::Type{S}) where {T, S}
+function NLSHS20(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     2,
     x0 = S([-2; 1]),
@@ -47,8 +48,7 @@ function NLSHS20(::Type{T}, ::Type{S}) where {T, S}
   return NLSHS20(meta, nls_meta, NLSCounters())
 end
 NLSHS20() = NLSHS20(Float64)
-NLSHS20(::Type{S}) where {S <: AbstractVector} = NLSHS20(eltype(S), S)
-NLSHS20(::Type{T}) where {T} = NLSHS20(T, Vector{T})
+NLSHS20(::Type{T}) where {T <: Number} = NLSHS20(Vector{T})
 
 function NLPModels.residual!(nls::NLSHS20, x::AbstractVector, Fx::AbstractVector)
   @lencheck 2 x Fx

--- a/src/nls/problems/nlslc.jl
+++ b/src/nls/problems/nlslc.jl
@@ -39,7 +39,8 @@ mutable struct NLSLC{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function NLSLC(::Type{T}, ::Type{S}) where {T, S}
+function NLSLC(::Type{S}) where {S}
+  T = eltype(S)
   meta = NLPModelMeta{T, S}(
     15,
     nnzj = 17,
@@ -58,8 +59,7 @@ function NLSLC(::Type{T}, ::Type{S}) where {T, S}
   return NLSLC(meta, nls_meta, NLSCounters())
 end
 NLSLC() = NLSLC(Float64)
-NLSLC(::Type{S}) where {S <: AbstractVector} = NLSLC(eltype(S), S)
-NLSLC(::Type{T}) where {T} = NLSLC(T, Vector{T})
+NLSLC(::Type{T}) where {T <: Number} = NLSLC(Vector{T})
 
 function NLPModels.residual!(nls::NLSLC, x::AbstractVector, Fx::AbstractVector)
   @lencheck 15 x Fx

--- a/src/nls/problems/nlslc.jl
+++ b/src/nls/problems/nlslc.jl
@@ -39,25 +39,27 @@ mutable struct NLSLC{T, S} <: AbstractNLSModel{T, S}
   counters::NLSCounters
 end
 
-function NLSLC(::Type{T}) where {T}
-  meta = NLPModelMeta{T, Vector{T}}(
+function NLSLC(::Type{T}, ::Type{S}) where {T, S}
+  meta = NLPModelMeta{T, S}(
     15,
     nnzj = 17,
     nnzh = 15,
     ncon = 11,
-    x0 = zeros(T, 15),
-    lcon = T[22.0; 1.0; -Inf; -11.0; -1.0; 1.0; -5.0; -6.0; -Inf * ones(3)],
-    ucon = T[22.0; Inf; 16.0; 9.0; -1.0; 1.0; Inf * ones(2); 1.0; 2.0; 3.0],
+    x0 = fill!(S(undef, 15), 0),
+    lcon = S([22; 1; -T(Inf); -11; -1; 1; -5; -6; -T(Inf) * ones(T, 3)]),
+    ucon = S([22; T(Inf); 16; 9; -1; 1; T(Inf) * ones(T, 2); 1; 2; 3]),
     name = "NLSLINCON",
     lin = 1:11,
     lin_nnzj = 17,
     nln_nnzj = 0,
   )
-  nls_meta = NLSMeta{T, Vector{T}}(15, 15, nnzj = 15, nnzh = 15)
+  nls_meta = NLSMeta{T, S}(15, 15, nnzj = 15, nnzh = 15)
 
   return NLSLC(meta, nls_meta, NLSCounters())
 end
 NLSLC() = NLSLC(Float64)
+NLSLC(::Type{S}) where {S <: AbstractVector} = NLSLC(eltype(S), S)
+NLSLC(::Type{T}) where {T} = NLSLC(T, Vector{T})
 
 function NLPModels.residual!(nls::NLSLC, x::AbstractVector, Fx::AbstractVector)
   @lencheck 15 x Fx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,10 +60,9 @@ end
   @testset "NLS tests of problem $p" begin
     nls_from_T = eval(Symbol(p))
     exclude = p == "LLS" ? [hess_coord, hess] : []
+    exclude = union(exclude, [obj, grad, residual]) # TODO: investigate
     @testset "GPU multiple precision support of problem $p" begin
-      CUDA.allowscalar() do # because nonlinear least squares use indexing
         multiple_precision_nls_array(nls_from_T, CuArray, linear_api = true, exclude = exclude)
-      end
     end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Distributed
 np = Sys.CPU_THREADS
 addprocs(np - 1)
 
-@everywhere using NLPModels, NLPModelsTest, Test
+@everywhere using CUDA, NLPModels, NLPModelsTest, Test
 
 @everywhere function nlp_tests(p)
   @testset "NLP tests of problem $p" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,9 @@ if CUDA.functional()
     @testset "NLP tests of problem $p" begin
       nlp_from_T = eval(Symbol(p))
       @testset "GPU multiple precision support of problem $p" begin
-        multiple_precision_nlp_array(nlp_from_T, CuArray, linear_api = true, exclude = [])
+        CUDA.allowscalar() do
+          multiple_precision_nlp_array(nlp_from_T, CuArray, linear_api = true, exclude = [])
+        end
       end
     end
   end
@@ -87,9 +89,10 @@ if CUDA.functional()
     @testset "NLS tests of problem $p" begin
       nls_from_T = eval(Symbol(p))
       exclude = p == "LLS" ? [hess_coord, hess] : []
-      exclude = union(exclude, [obj, grad, residual]) # TODO: investigate
       @testset "GPU multiple precision support of problem $p" begin
+        CUDA.allowscalar() do
           multiple_precision_nls_array(nls_from_T, CuArray, linear_api = true, exclude = exclude)
+        end
       end
     end
   end


### PR DESCRIPTION
This is still WIP:
- [x] Generalize the test with Vector{T]
- [x] Add optional tests with CUDA
- [x] Fix issue with residual for NLS (use allowscalar)
- [x] update some of the NLP Model API to be compatiable with other vector types (for instance: `hess_coord`)