### PR TITLE
Remove fix -50 in coord memory nlp allocation tests

### DIFF
--- a/src/nlp/coord-memory.jl
+++ b/src/nlp/coord-memory.jl
@@ -20,7 +20,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
     V = zeros(nlp.meta.nnzh)
     hess_coord!(nlp, x, V)
     al2 = @allocated hess_coord!(nlp, x, V)
-    @test al2 < al1
+    @test al2 < al1 | al2 == 0
   end
 
   if m > 0
@@ -29,7 +29,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       al1 = @allocated vals = hess_coord(nlp, x, y)
       hess_coord!(nlp, x, y, V)
       al2 = @allocated hess_coord!(nlp, x, y, V)
-      @test al2 < al1
+      @test al2 < al1 | al2 == 0
     end
 
     if jth_hess_coord ∉ exclude
@@ -37,7 +37,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       al1 = @allocated vals = jth_hess_coord(nlp, x, m)
       jth_hess_coord!(nlp, x, m, V)
       al2 = @allocated jth_hess_coord!(nlp, x, m, V)
-      @test al2 < al1
+      @test al2 < al1 | al2 == 0
     end
 
     if jac_coord ∉ exclude
@@ -46,14 +46,14 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       V = zeros(nlp.meta.nnzj)
       jac_coord!(nlp, x, vals)
       al2 = @allocated jac_coord!(nlp, x, vals)
-      @test al2 < al1
+      @test al2 < al1 | al2 == 0
       if linear_api && nlp.meta.nlin > 0
         vals = jac_lin_coord(nlp, x)
         al1 = @allocated vals = jac_lin_coord(nlp, x)
         V = zeros(nlp.meta.lin_nnzj)
         jac_lin_coord!(nlp, x, vals)
         al2 = @allocated jac_lin_coord!(nlp, x, vals)
-        @test al2 < al1
+        @test al2 < al1 | al2 == 0
       end
       if linear_api && nlp.meta.nnln > 0
         vals = jac_nln_coord(nlp, x)
@@ -61,7 +61,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
         V = zeros(nlp.meta.nln_nnzj)
         jac_nln_coord!(nlp, x, vals)
         al2 = @allocated jac_nln_coord!(nlp, x, vals)
-        @test al2 < al1
+        @test al2 < al1 | al2 == 0
       end
     end
   end

--- a/src/nlp/coord-memory.jl
+++ b/src/nlp/coord-memory.jl
@@ -20,7 +20,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
     V = zeros(nlp.meta.nnzh)
     hess_coord!(nlp, x, V)
     al2 = @allocated hess_coord!(nlp, x, V)
-    @test al2 < al1 | al2 == 0
+    @test (al2 < al1) | (al2 == 0)
   end
 
   if m > 0
@@ -29,7 +29,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       al1 = @allocated vals = hess_coord(nlp, x, y)
       hess_coord!(nlp, x, y, V)
       al2 = @allocated hess_coord!(nlp, x, y, V)
-      @test al2 < al1 | al2 == 0
+      @test (al2 < al1) | (al2 == 0)
     end
 
     if jth_hess_coord ∉ exclude
@@ -37,7 +37,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       al1 = @allocated vals = jth_hess_coord(nlp, x, m)
       jth_hess_coord!(nlp, x, m, V)
       al2 = @allocated jth_hess_coord!(nlp, x, m, V)
-      @test al2 < al1 | al2 == 0
+      @test (al2 < al1) | (al2 == 0)
     end
 
     if jac_coord ∉ exclude
@@ -46,14 +46,14 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       V = zeros(nlp.meta.nnzj)
       jac_coord!(nlp, x, vals)
       al2 = @allocated jac_coord!(nlp, x, vals)
-      @test al2 < al1 | al2 == 0
+      @test (al2 < al1) | (al2 == 0)
       if linear_api && nlp.meta.nlin > 0
         vals = jac_lin_coord(nlp, x)
         al1 = @allocated vals = jac_lin_coord(nlp, x)
         V = zeros(nlp.meta.lin_nnzj)
         jac_lin_coord!(nlp, x, vals)
         al2 = @allocated jac_lin_coord!(nlp, x, vals)
-        @test al2 < al1 | al2 == 0
+        @test (al2 < al1) | (al2 == 0)
       end
       if linear_api && nlp.meta.nnln > 0
         vals = jac_nln_coord(nlp, x)
@@ -61,7 +61,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
         V = zeros(nlp.meta.nln_nnzj)
         jac_nln_coord!(nlp, x, vals)
         al2 = @allocated jac_nln_coord!(nlp, x, vals)
-        @test al2 < al1 | al2 == 0
+        @test (al2 < al1) | (al2 == 0)
       end
     end
   end

--- a/src/nlp/coord-memory.jl
+++ b/src/nlp/coord-memory.jl
@@ -20,7 +20,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
     V = zeros(nlp.meta.nnzh)
     hess_coord!(nlp, x, V)
     al2 = @allocated hess_coord!(nlp, x, V)
-    @test al2 < al1 - 50
+    @test al2 < al1
   end
 
   if m > 0
@@ -29,7 +29,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       al1 = @allocated vals = hess_coord(nlp, x, y)
       hess_coord!(nlp, x, y, V)
       al2 = @allocated hess_coord!(nlp, x, y, V)
-      @test al2 < al1 - 50
+      @test al2 < al1
     end
 
     if jth_hess_coord ∉ exclude
@@ -37,7 +37,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       al1 = @allocated vals = jth_hess_coord(nlp, x, m)
       jth_hess_coord!(nlp, x, m, V)
       al2 = @allocated jth_hess_coord!(nlp, x, m, V)
-      @test al2 < al1 - 50
+      @test al2 < al1
     end
 
     if jac_coord ∉ exclude
@@ -46,14 +46,14 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
       V = zeros(nlp.meta.nnzj)
       jac_coord!(nlp, x, vals)
       al2 = @allocated jac_coord!(nlp, x, vals)
-      @test al2 < al1 - 50
+      @test al2 < al1
       if linear_api && nlp.meta.nlin > 0
         vals = jac_lin_coord(nlp, x)
         al1 = @allocated vals = jac_lin_coord(nlp, x)
         V = zeros(nlp.meta.lin_nnzj)
         jac_lin_coord!(nlp, x, vals)
         al2 = @allocated jac_lin_coord!(nlp, x, vals)
-        @test al2 < al1 - 50
+        @test al2 < al1
       end
       if linear_api && nlp.meta.nnln > 0
         vals = jac_nln_coord(nlp, x)
@@ -61,7 +61,7 @@ function coord_memory_nlp(nlp::AbstractNLPModel; linear_api = false, exclude = [
         V = zeros(nlp.meta.nln_nnzj)
         jac_nln_coord!(nlp, x, vals)
         al2 = @allocated jac_nln_coord!(nlp, x, vals)
-        @test al2 < al1 - 50
+        @test al2 < al1
       end
     end
   end


### PR DESCRIPTION
Close #113 
The -50 is kind of arbitrary and fails on pre-release Julia versions